### PR TITLE
ATED-1746 upgraded domain from 3.1.0 to 3.4.0

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -32,7 +32,7 @@ private object AppDependencies {
     json % "provided",
     ws % "provided",
     "uk.gov.hmrc" %% "http-verbs" % "3.3.0",
-    "uk.gov.hmrc" %% "domain" % "3.1.0"
+    "uk.gov.hmrc" %% "domain" % "3.4.0"
   )
 
   trait TestDependencies {


### PR DESCRIPTION
This is so that the updated AtedUtr format can be used within mdtp
