### PR TITLE
PLATOPS-1619: upgrade to Play 2.5.19

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -30,8 +30,9 @@ private object AppDependencies {
   val compile = Seq(
     "com.typesafe.play" %% "play" % PlayVersion.current % "provided",
     json % "provided",
-    "uk.gov.hmrc" %% "http-verbs-play-25" % "0.6.0",
-    "uk.gov.hmrc" %% "domain" % "4.1.0"
+    "uk.gov.hmrc" %% "http-verbs" % "8.10.0-play-25",
+    "uk.gov.hmrc" %% "domain" % "4.1.0",
+    "uk.gov.hmrc" %% "time" % "3.2.0"
   )
 
   trait TestDependencies {
@@ -46,7 +47,7 @@ private object AppDependencies {
         "org.scalatest" %% "scalatest" % "2.2.4" % scope,
         "org.pegdown" % "pegdown" % "1.5.0" % scope,
         "com.github.tomakehurst" % "wiremock" % "1.54" % scope excludeAll ExclusionRule(organization = "org.apache.httpcomponents"),
-        "uk.gov.hmrc" %% "hmrctest" % "2.3.0" % scope,
+        "uk.gov.hmrc" %% "hmrctest" % "3.3.0" % scope,
         "uk.gov.hmrc" %% "http-verbs-test" % "1.1.0" % scope,
         "org.mockito" % "mockito-all" % "1.9.5" % "test"
       )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.4.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")

--- a/src/main/scala/uk/gov/hmrc/play/frontend/auth/SessionTimeoutWrapper.scala
+++ b/src/main/scala/uk/gov/hmrc/play/frontend/auth/SessionTimeoutWrapper.scala
@@ -16,14 +16,13 @@
 
 package uk.gov.hmrc.play.frontend.auth
 
-import org.joda.time.{DateTime, DateTimeZone, Duration}
+import org.joda.time.DateTime
 import play.api.Logger
-import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
+import play.api.mvc._
+import uk.gov.hmrc.http.SessionKeys
+import uk.gov.hmrc.play.HeaderCarrierConverter
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import uk.gov.hmrc.time.DateTimeUtils
-import play.api.mvc._
-import uk.gov.hmrc.play.HeaderCarrierConverter
-
 import scala.concurrent._
 
 trait SessionTimeoutWrapper {


### PR DESCRIPTION
We have had to update all the libraries on the platform to use Play 2.5.19 to address a security vulnerability with a version of logback that is included in play (< 2.5.14) which is fixed in play 2.5.19.  